### PR TITLE
utils: include sys/stat.h

### DIFF
--- a/utils.h
+++ b/utils.h
@@ -2,6 +2,7 @@
 #define VOIDNSRUN_UTILS_H
 
 #include <stdbool.h>
+#include <sys/stat.h>
 #include "config.h"
 
 struct strarray {


### PR DESCRIPTION
This fixes `make undo`:
```
$ make undo
gcc -O2 -std=c99 -Wall -W -c voidnsundo.c -I. -o voidnsundo.o
In file included from voidnsundo.c:17:
utils.h:24:1: error: unknown type name 'mode_t'
   24 | mode_t getmode(const char *s);
      | ^~~~~~
make: *** [Makefile:41: voidnsundo.o] Error 1
```